### PR TITLE
add github action to automatically publish new releases

### DIFF
--- a/.github/workflows/publish-to-redaxo.yml
+++ b/.github/workflows/publish-to-redaxo.yml
@@ -1,0 +1,17 @@
+name: Publish release
+
+on:
+    release:
+        types:
+            - published
+
+jobs:
+    redaxo_publish:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: FriendsOfREDAXO/installer-action@1.0.0
+              with:
+                  myredaxo-username: ${{ secrets.MYREDAXO_USERNAME }}
+                  myredaxo-api-key: ${{ secrets.MYREDAXO_API_KEY }}
+                  description: ${{ github.event.release.body }}


### PR DESCRIPTION
https://github.com/FriendsOfREDAXO/installer-action

Secrets sind bereits innerhalb der Organization hinterlegt, die Action kann also nach Merge direkt genutzt werden.