### PR TITLE
copy selectors to clipboard

### DIFF
--- a/assets/redactor.js
+++ b/assets/redactor.js
@@ -22,4 +22,42 @@ $(document).on('rex:ready',function(event, container) {
             }
         }
     })
+    
+    document.querySelectorAll('div[data-redactor-copy-yform]').forEach(function(el) {
+        el.addEventListener('click', data_redactor_copy_yform)
+    })
+    document.querySelectorAll('div[data-redactor-copy-generic]').forEach(function(el) {
+        el.addEventListener('click', data_redactor_copy_generic)
+    })
+
 });
+
+function data_redactor_copy_yform(event) {
+    // Holt das aktuelle Element, auf das geklickt wurde
+    var element = event.currentTarget;
+    // Fügt die Klasse "copied" zum aktuellen Element hinzu
+    element.classList.add('copied');
+    // Sucht das icon-Element im aktuellen Element
+    var iconElement = element.querySelector('i');
+    // Entfernt die Klasse "fa-clone" vom i-Element
+    iconElement.classList.remove('fa-clone');
+    // Fügt die Klasse "fa-check" zum i-Element hinzu
+    iconElement.classList.add('fa-check');
+    // Kopiert den Wert des data-wildcard-copy Attributs in die Zwischenablage
+    navigator.clipboard.writeText(element.getAttribute('data-redactor-copy-yform'));
+};
+
+function data_redactor_copy_generic(event) {
+    // Holt das aktuelle Element, auf das geklickt wurde
+    var element = event.currentTarget;
+    // Fügt die Klasse "copied" zum aktuellen Element hinzu
+    element.classList.add('copied');
+    // Sucht das icon-Element im aktuellen Element
+    var iconElement = element.querySelector('i');
+    // Entfernt die Klasse "fa-clone" vom i-Element
+    iconElement.classList.remove('fa-clone');
+    // Fügt die Klasse "fa-check" zum i-Element hinzu
+    iconElement.classList.add('fa-check');
+    // Kopiert den Wert des data-wildcard-copy Attributs in die Zwischenablage
+    navigator.clipboard.writeText(element.getAttribute('data-redactor-copy-generic'));
+};

--- a/pages/profile.php
+++ b/pages/profile.php
@@ -135,6 +135,19 @@ if ($func == 'add' || $func == 'edit') {
     $list->setColumnLabel('name', rex_i18n::msg('redactor_profile_name'));
     $list->setColumnLabel('description', rex_i18n::msg('redactor_profile_description'));
     $list->setColumnLabel('selector', rex_i18n::msg('redactor_profile_selector'));
+
+    $list->setColumnFormat('selector', 'custom', static function ($params) {
+
+        $yform_code = '{"class":"form-control '.substr($params['list']->getValue('selector'), 1).'"}';
+        // remove first character of list selector
+        $selector = substr($params['list']->getValue('selector'), 1);
+        $generic_code = ''.$params['list']->getValue('selector').'';
+        $return = '<div class="text-nowrap" data-redactor-copy-generic="'.$generic_code.'" role="button"> <i class="rex-icon fa-clone"></i> <code>'.$generic_code.'</code></div>';
+        $return .= '<div class="text-nowrap" data-redactor-copy-yform="'.$yform_code.'" role="button"> <i class="rex-icon fa-clone"></i> <code>'.$yform_code.'</code></div>';
+
+        return $return;
+
+    });
     $list->setColumnLabel($functions, rex_i18n::msg('redactor_profile_functions'));
 
     $list->setColumnParams('name', ['id' => '###id###', 'func' => 'edit']);

--- a/pages/profile.php
+++ b/pages/profile.php
@@ -142,8 +142,8 @@ if ($func == 'add' || $func == 'edit') {
         // remove first character of list selector
         $selector = substr($params['list']->getValue('selector'), 1);
         $generic_code = ''.$params['list']->getValue('selector').'';
-        $return = '<div class="text-nowrap" data-redactor-copy-generic="'.$generic_code.'" role="button"> <i class="rex-icon fa-clone"></i> <code>'.$generic_code.'</code></div>';
-        $return .= '<div class="text-nowrap" data-redactor-copy-yform="'.$yform_code.'" role="button"> <i class="rex-icon fa-clone"></i> <code>'.$yform_code.'</code></div>';
+        $return = '<div class="text-nowrap" data-redactor-copy-generic="'.htmlspecialchars($generic_code).'" role="button"> <i class="rex-icon fa-clone"></i> <code>'.$generic_code.'</code></div>';
+        $return .= '<div class="text-nowrap" data-redactor-copy-yform="'.htmlspecialchars($yform_code).'" role="button"> <i class="rex-icon fa-clone"></i> <code>'.$yform_code.'</code></div>';
 
         return $return;
 


### PR DESCRIPTION
Die Möglichkeit, direkt den Selektor zu kopieren inkl YForm-JSON-Attribut für direktes Kopieren und Einfügen in ein YForm-Textarea-Value.

![image](https://github.com/FriendsOfREDAXO/redactor/assets/3855487/95b16776-086e-459d-9b2d-7a56f0473b76)
