### PR TITLE
Standard-Profile und Beispiel - html und rückgängig/wiederholen richtig trennen

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Bindet den WYSIWYG-Editor [Redactor](http://imperavi.com/redactor/) in Version 3
 Ein Profil wird entsprechend wie folgt angelegt: 
 
 ```
-html,undo,|,redo,h1,h2,h3,h4,bold,italic,|,image,blockquote,lists[indent],ol,ul,linkExternal,linkInternal,hr,linkYForm[rex_yform_test=last_name|rex_yform_news=title],table,widget
+html,|,undo,redo,|,h1,h2,h3,h4,bold,italic,|,image,blockquote,lists[indent],ol,ul,linkExternal,linkInternal,hr,linkYForm[rex_yform_test=last_name|rex_yform_news=title],table,widget
 ```
 
 Weitere Einstellungen können hinterlegt werden, dazu die Parameter des Vendors beachten: <https://imperavi.com/redactor/docs/settings/overview/>

--- a/pages/profile.php
+++ b/pages/profile.php
@@ -99,7 +99,7 @@ if ($func == 'add' || $func == 'edit') {
     $field->setLabel(rex_i18n::msg('redactor_profile_plugins'));
     $field->setNotice(rex_i18n::msg('redactor_profile_plugins_notice'));
     if($field->getValue() === null) {
-        $field->setValue("html,undo,|,redo,h1,h2,h3,h4,bold,italic,|,image,blockquote,lists[indent],ol,ul,linkExternal,linkInternal,hr,linkYForm[rex_yform_test=last_name|rex_yform_news=title],table,widget");
+        $field->setValue("html,|,undo,redo,|,h1,h2,h3,h4,bold,italic,|,image,blockquote,lists[indent],ol,ul,linkExternal,linkInternal,hr,linkYForm[rex_yform_test=last_name|rex_yform_news=title],table,widget");
     }
 
     $field = $form->addTextAreaField('settings');


### PR DESCRIPTION
vorher

`html,undo,|,redo,h1`

nachher

`html,|,undo,redo,|,h1`
