### PR TITLE
Redactor mit Vanilla JS ohne jQuery ermöglichen

### DIFF
--- a/assets/plugins.vanilla/alignment.js
+++ b/assets/plugins.vanilla/alignment.js
@@ -1,0 +1,68 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+(function ($R) {
+    $R.add('plugin', 'alignment', {
+        init: function (app) {
+            this.app = app;
+            this.opts = app.opts;
+            this.lang = app.lang;
+            this.block = app.block;
+            this.toolbar = app.toolbar;
+        },
+        // public
+        start: function () {
+            let dropdown = {};
+
+            dropdown.left = {
+                title: redactorTranslations.alignment_left_title,
+                api: 'plugin.alignment.set',
+                args: 'left'
+            };
+            dropdown.center = {
+                title: redactorTranslations.alignment_center_title,
+                api: 'plugin.alignment.set',
+                args: 'center'
+            };
+            dropdown.right = {
+                title: redactorTranslations.alignment_right_title,
+                api: 'plugin.alignment.set',
+                args: 'right'
+            };
+            dropdown.justify = {
+                title: redactorTranslations.alignment_justify_title,
+                api: 'plugin.alignment.set',
+                args: 'justify'
+            };
+
+            var button = this.toolbar.addButton('alignment', {
+                title: redactorTranslations.alignment_title
+            });
+            button.setIcon('<i class="re-icon-alignment"></i>');
+            button.setDropdown(dropdown);
+        },
+        set: function (type) {
+            if (type === 'left' && this.opts.direction === 'ltr') {
+                return this._remove();
+            }
+
+            var args = {
+                style: {'text-align': type}
+            };
+
+            this.block.toggle(args);
+        },
+
+        // private
+        _remove: function () {
+            this.block.remove({style: 'text-align'});
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/blockquote.js
+++ b/assets/plugins.vanilla/blockquote.js
@@ -1,0 +1,31 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'blockquote', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.blockquote_title,
+                icon: false,
+                tooltip: redactorTranslations.blockquote_tooltip,
+                api: 'module.block.format',
+                args: {
+                    tag: 'blockquote'
+                }
+            };
+
+            this.toolbar.addButton('blockquote', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/bold.js
+++ b/assets/plugins.vanilla/bold.js
@@ -1,0 +1,31 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'bold', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.bold_title,
+                icon: true,
+                tooltip: redactorTranslations.bold_tooltip,
+                api: 'module.inline.format',
+                args: {
+                    tag: 'b'
+                }
+            };
+
+            this.toolbar.addButton('bold', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/cleaner.js
+++ b/assets/plugins.vanilla/cleaner.js
@@ -1,0 +1,51 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'cleaner', {
+        init: function (app) {
+            this.app = app;
+            this.block = app.block;
+            this.inline = app.inline;
+            this.toolbar = app.toolbar;
+            this.insertion = app.insertion;
+            this.selection = app.selection;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.cleaner_title,
+                icon: true,
+                tooltip: redactorTranslations.cleaner_tooltip,
+                api: 'plugin.cleaner.format'
+            };
+
+            let button = this.toolbar.addButton('cleaner', obj);
+            button.setIcon('<i class="fa fa-eraser"></i>');
+        },
+
+        format: function () {
+            if (this.selection.is()) {
+                this.inline.clearFormat();
+                this.inline.clearAttr();
+                this.inline.clearClass();
+                this.inline.clearStyle();
+
+                // get the current selection
+                // let html = this.selection.getHtml();
+
+                // Strip out html
+                // html = html.replace(/(<([^>]+)>)/ig, "");
+                //
+                // this.insertion.set(html);
+            }
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/clip.js
+++ b/assets/plugins.vanilla/clip.js
@@ -1,0 +1,54 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'clip', {
+        init: function (app) {
+            this.opts = app.opts;
+            this.insertion = app.insertion;
+            this.toolbar = app.toolbar;
+
+            if ('redaxo' in this.opts && 'clip' in this.opts.redaxo) {
+                this.clipopts = app.opts.redaxo.clip;
+            } else {
+                return false;
+            }
+        },
+
+        // public
+        start: function () {
+            let dropdown = {};
+
+            $.each(this.clipopts, function (i, data) {
+                let title = data[0];
+                let clip = data[1];
+
+                dropdown[i] = {
+                    title: title,
+                    api: 'plugin.clip.set',
+                    args: clip
+                };
+            });
+
+            let obj = {
+                title: redactorTranslations.clip_title,
+                icon: true,
+                tooltip: redactorTranslations.clip_tooltip
+            };
+            // Don't use name like clip. This has a conflict with the vendor.
+            let button = this.toolbar.addButton('for-clip', obj);
+            button.setIcon('<i class="re-icon-clips"></i>');
+            button.setDropdown(dropdown);
+        },
+
+        set: function (data) {
+            this.insertion.insertHtml(data);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/deleted.js
+++ b/assets/plugins.vanilla/deleted.js
@@ -1,0 +1,31 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'deleted', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.deleted_title,
+                icon: true,
+                tooltip: redactorTranslations.deleted_tooltip,
+                api: 'module.inline.format',
+                args: {
+                    tag: 'del'
+                }
+            };
+
+            this.toolbar.addButton('deleted', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/format.js
+++ b/assets/plugins.vanilla/format.js
@@ -1,0 +1,90 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'format', {
+        init: function (app) {
+            this.opts = app.opts;
+            this.block = app.block;
+            this.selection = app.selection;
+            this.toolbar = app.toolbar;
+
+            let opts = this.opts.formatting;
+            if ('redaxo' in this.opts && 'format' in this.opts.redaxo) {
+                opts = app.opts.redaxo.format;
+            }
+            opts = opts.map(function (data) {
+                if (typeof data === 'string') {
+                    return [data, data];
+                }
+                return data;
+            });
+
+            this.formatopts = opts;
+        },
+
+        // public
+        start: function () {
+            let dropdown = {};
+
+            this.formatopts.forEach((data, i) => {
+                let title = data[0];
+                let tag = data[0];
+                let cssClass = '';
+
+                if (data.length >= 2) {
+                    let params = data[1].split('.');
+                    tag = params[0];
+
+                    if (params.length === 2) {
+                        cssClass = params[1];
+                    }
+                }
+
+                if (cssClass !== '') {
+                    title = `<span class="${cssClass}">${title}</span>`;
+                }
+
+                dropdown[i] = {
+                    title: title,
+                    api: 'plugin.format.set',
+                    args: {
+                        tag: tag,
+                        cssClass: cssClass
+                    }
+                };
+            });
+
+            let obj = {
+                title: redactorTranslations.format_title,
+                icon: true,
+                tooltip: redactorTranslations.format_tooltip
+            };
+            // Don't use name like format. This has a conflict with the vendor.
+            let button = this.toolbar.addButton('for-format', obj);
+            button.setIcon('<i class="re-icon-format"></i>');
+            button.setDropdown(dropdown);
+        },
+
+        set: function (data) {
+            let args = {
+                'tag': data.tag,
+                'type': 'toggle'
+            };
+
+            if (data.cssClass !== '') {
+                args.class = data.cssClass;
+            }
+            let block = this.selection.getBlock();
+            let element = $R.dom(block);
+            element.removeAttr('class');
+            this.block.format(args);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/h1.js
+++ b/assets/plugins.vanilla/h1.js
@@ -1,0 +1,31 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'h1', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.h1_title,
+                icon: false,
+                tooltip: redactorTranslations.h1_tooltip,
+                api: 'module.block.format',
+                args: {
+                    tag: 'h1'
+                }
+            };
+
+            this.toolbar.addButton('h1', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/h2.js
+++ b/assets/plugins.vanilla/h2.js
@@ -1,0 +1,31 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'h2', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.h2_title,
+                icon: false,
+                tooltip: redactorTranslations.h2_tooltip,
+                api: 'module.block.format',
+                args: {
+                    tag: 'h2'
+                }
+            };
+
+            this.toolbar.addButton('h2', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/h3.js
+++ b/assets/plugins.vanilla/h3.js
@@ -1,0 +1,31 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'h3', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.h3_title,
+                icon: false,
+                tooltip: redactorTranslations.h3_tooltip,
+                api: 'module.block.format',
+                args: {
+                    tag: 'h3'
+                }
+            };
+
+            this.toolbar.addButton('h3', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/h4.js
+++ b/assets/plugins.vanilla/h4.js
@@ -1,0 +1,31 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'h4', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.h4_title,
+                icon: false,
+                tooltip: redactorTranslations.h4_tooltip,
+                api: 'module.block.format',
+                args: {
+                    tag: 'h4'
+                }
+            };
+
+            this.toolbar.addButton('h4', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/h5.js
+++ b/assets/plugins.vanilla/h5.js
@@ -1,0 +1,31 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'h5', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.h5_title,
+                icon: false,
+                tooltip: redactorTranslations.h5_tooltip,
+                api: 'module.block.format',
+                args: {
+                    tag: 'h5'
+                }
+            };
+
+            this.toolbar.addButton('h5', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/h6.js
+++ b/assets/plugins.vanilla/h6.js
@@ -1,0 +1,31 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'h6', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.h6_title,
+                icon: false,
+                tooltip: redactorTranslations.h6_tooltip,
+                api: 'module.block.format',
+                args: {
+                    tag: 'h6'
+                }
+            };
+
+            this.toolbar.addButton('h6', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/hr.js
+++ b/assets/plugins.vanilla/hr.js
@@ -1,0 +1,27 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'hr', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.hr_title,
+                api: 'module.line.insert'
+            };
+
+            let button = this.toolbar.addButton('hr', obj);
+            button.setIcon('<i class="re-icon-line"></i>');
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/html.js
+++ b/assets/plugins.vanilla/html.js
@@ -1,0 +1,27 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'html', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: 'HTML',
+                icon: true,
+                api: 'module.source.toggle'
+            };
+
+            this.toolbar.addButton('html', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/image.js
+++ b/assets/plugins.vanilla/image.js
@@ -1,0 +1,59 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'image', {
+        init: function (app) {
+            this.app = app;
+            this.opts = app.opts;
+            this.toolbar = app.toolbar;
+            this.insertion = app.insertion;
+            this.selection = app.selection;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.image_title,
+                observe: 'link',
+                api: 'plugin.image.open'
+            };
+
+            let button = this.toolbar.addButton('image', obj);
+            button.setIcon('<i class="rex-icon rex-icon-media"></i>');
+        },
+
+        open: function () {
+            let params = 'redactor_image';
+            if ('redactor_rex_media_getImageTypes' in rex) {
+                params += '&args[types]='+rex.redactor_rex_media_getImageTypes.join(',');
+            }
+            let that = this;
+            let mediaPool = openMediaPool(params);
+            mediaPool.addEventListener('rex:selectMedia', function (event) {
+                event.preventDefault();
+                mediaPool.close();
+                let filename = event.detail; // Assuming `event.detail` contains the filename
+                let options = {
+                    url: rex.redactor_imageUrlPath + filename,
+                    label: filename
+                };
+                that._insert(options);
+            });
+        },
+
+        // private
+        _insert: function (data) {
+            if (this.selection.getText() !== '') {
+                data.label = this.selection.getText();
+            }
+            this.insertion.insertRaw('<img src="'+data.url+'" alt="" />');
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/indent.js
+++ b/assets/plugins.vanilla/indent.js
@@ -1,0 +1,28 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'indent', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.indent_title,
+                icon: true,
+                api: 'module.list.indent',
+                observe: 'list'
+            };
+
+            this.toolbar.addButton('indent', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/italic.js
+++ b/assets/plugins.vanilla/italic.js
@@ -1,0 +1,31 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'italic', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.italic_title,
+                icon: true,
+                tooltip: redactorTranslations.italic_tooltip,
+                api: 'module.inline.format',
+                args: {
+                    tag: 'i'
+                }
+            };
+
+            this.toolbar.addButton('italic', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/linkEmail.js
+++ b/assets/plugins.vanilla/linkEmail.js
@@ -1,0 +1,162 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'linkEmail', {
+        init: function (app) {
+            this.app = app;
+            this.toolbar = app.toolbar;
+            this.insertion = app.insertion;
+            this.inspector = app.inspector;
+            this.selection = app.selection;
+            this.cleaner = app.cleaner;
+            this.component = app.component;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.linkEmail_title,
+                icon: false,
+                tooltip: redactorTranslations.linkEmail_tooltip,
+                api: 'plugin.linkEmail.open'
+            };
+
+            let button = this.toolbar.addButton('linkEmail', obj);
+            button.setIcon('<i class="re-icon-link"></i><i class="fa fa-envelope-o" style="margin-left: .1em; vertical-align: top;"></i>');
+        },
+
+        open: function () {
+            this.$currentItem = this._getCurrent();
+
+            var options = {
+                title: redactorTranslations.linkEmail_title,
+                name: 'linkEmailModal',
+                width: '500px',
+                height: false,
+                handle: 'insert',
+                commands: {
+                    insert: {title: (this.$currentItem) ? redactorTranslations.save : redactorTranslations.insert},
+                    cancel: {title: redactorTranslations.cancel,}
+                }
+            };
+
+            this.app.api('module.modal.build', options);
+        },
+
+        onmodal: {
+            'linkEmailModal': {
+                open: function ($modal, $form) {
+                    if (this.selection.getText() !== '') {
+                        $form.setData({
+                            'linkEmailText': this.selection.getText()
+                        });
+                    }
+                },
+                opened: function ($modal, $form) {
+                    $form.getField('linkEmailAddress').focus();
+                    if (this.$currentItem) {
+                        let $el = $R.dom(this.$currentItem);
+                        let email = decodeURI($el.attr('href').substring(7));
+                        let text = $el.text();
+                        $form.getField('linkEmailAddress').val(email);
+                        $form.getField('linkEmailText').val(text);
+                    }
+                },
+                insert: function ($modal, $form) {
+                    let data = $form.getData();
+                    if (this._validateData($form, data)) {
+                        this._insert(data);
+                    }
+                },
+            }
+        },
+
+        modals: {
+            'linkEmailModal': '<form action="">'
+                + '<div class="form-item">'
+                + '<label>' + redactorTranslations.linkEmail_label_email + ' <span class="req">*</span</label>'
+                + '<input name="linkEmailAddress" type="text" />'
+                + '</div>'
+                + '<div class="form-item">'
+                + '<label>' + redactorTranslations.linkEmail_label_text + '</label>'
+                + '<input name="linkEmailText" type="text" />'
+                + '</div>'
+                + '</form>'
+        },
+
+        oncontextbar: function (e, contextbar) {
+
+            let data = this.inspector.parse(e.target);
+            if (data.isLink()) {
+                let node = data.getLink();
+                let $el = $R.dom(node);
+
+                let url = $el.attr('href');
+                if (url.substring(0, 7) === 'mailto:') {
+                    let $point = $R.dom('<a>');
+
+                    $point.text(url.substring(7));
+                    $point.attr('href', url);
+
+                    var buttons = {
+                        'link': {
+                            title: $point,
+                            html: url.substring(7)
+                        },
+                        'edit': {
+                            title: redactorTranslations.edit,
+                            api: 'plugin.linkEmail.open',
+                            args: node
+                        },
+                        'unlink': {
+                            title: redactorTranslations.unlink,
+                            api: 'module.link.unlink'
+                        }
+                    };
+                    contextbar.set(e, node, buttons, 'bottom');
+                }
+            }
+        },
+
+        _getCurrent: function () {
+            var current = this.selection.getCurrent();
+            var data = this.inspector.parse(current);
+            if (data.isLink()) {
+                return this.component.build(data.getLink());
+            }
+        },
+
+        _insert: function (data) {
+            // close the modal
+            this.app.api('module.modal.close');
+
+            // check the data
+            if (data.linkEmailAddress.trim() === '') {
+                return;
+            }
+            if (data.linkEmailText.trim() === '') {
+                data.linkEmailText = data.linkEmailAddress;
+            }
+
+            let current = this._getCurrent();
+            if (current) {
+                let element = $R.dom(current);
+                element.attr('href', 'mailto:'+data.linkEmailAddress);
+                element.text(data.linkEmailText);
+            } else {
+                this.insertion.insertRaw('<a href="mailto:' + data.linkEmailAddress + '">' + data.linkEmailText + '</a>');
+            }
+        },
+
+        _validateData: function ($form, data) {
+            return (data.linkEmailAddress.trim() === '') ? $form.setError('linkEmailAddress') : true;
+        },
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/linkExternal.js
+++ b/assets/plugins.vanilla/linkExternal.js
@@ -1,0 +1,28 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'linkExternal', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.link_insert,
+                observe: 'link',
+                api: 'module.link.open'
+            };
+
+            let button = this.toolbar.addButton('linkExternal', obj);
+            button.setIcon('<i class="re-icon-link"></i>');
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/linkInternal.js
+++ b/assets/plugins.vanilla/linkInternal.js
@@ -1,0 +1,55 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'linkInternal', {
+        init: function (app) {
+            this.app = app;
+            this.opts = app.opts;
+            this.toolbar = app.toolbar;
+            this.insertion = app.insertion;
+            this.selection = app.selection;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.linkInternal_title,
+                observe: 'link',
+                api: 'plugin.linkInternal.open'
+            };
+
+            let button = this.toolbar.addButton('linkInternal', obj);
+            button.setIcon('<i class="rex-icon rex-icon-open-linkmap"></i>');
+        },
+
+        open: function () {
+            let that = this;
+            let linkMap = openLinkMap('', '&clang=' + rex.redactor_rex_clang_getCurrentId);
+            $(linkMap).on('rex:selectLink', function (event, url, label) {
+                event.preventDefault();
+                linkMap.close();
+                label = label.replace(new RegExp(that.opts.redaxo.regex.id, 'gi'), "$1");
+                let options = {
+                    url: url,
+                    label: label
+                };
+                that._insert(options);
+            });
+        },
+
+        // private
+        _insert: function (data) {
+            if (this.selection.getText() !== '') {
+                data.label = this.selection.getText();
+            }
+            this.insertion.insertRaw('<a href="' + data.url + '">' + data.label + '</a>');
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/linkMedia.js
+++ b/assets/plugins.vanilla/linkMedia.js
@@ -1,0 +1,54 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'linkMedia', {
+        init: function (app) {
+            this.app = app;
+            this.opts = app.opts;
+            this.toolbar = app.toolbar;
+            this.insertion = app.insertion;
+            this.selection = app.selection;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.linkMedia_title,
+                observe: 'link',
+                api: 'plugin.linkMedia.open'
+            };
+
+            let button = this.toolbar.addButton('linkMedia', obj);
+            button.setIcon('<i class="re-icon-link"></i><i class="rex-icon rex-icon-media" style="margin-left: .1em; vertical-align: top;"></i>');
+        },
+
+        open: function () {
+            let that = this;
+            let mediaPool = openMediaPool('redactor_linkMedia');
+            $(mediaPool).on('rex:selectMedia', function (event, filename) {
+                event.preventDefault();
+                mediaPool.close();
+                let options = {
+                    url: rex.redactor_rex_url_media+filename,
+                    label: filename
+                };
+                that._insert(options);
+            });
+        },
+
+        // private
+        _insert: function (data) {
+            if (this.selection.getText() !== '') {
+                data.label = this.selection.getText();
+            }
+            this.insertion.insertRaw('<a href="' + data.url + '">' + data.label + '</a>');
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/linkTelephone.js
+++ b/assets/plugins.vanilla/linkTelephone.js
@@ -1,0 +1,161 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'linkTelephone', {
+        init: function (app) {
+            this.app = app;
+            this.toolbar = app.toolbar;
+            this.insertion = app.insertion;
+            this.inspector = app.inspector;
+            this.selection = app.selection;
+            this.cleaner = app.cleaner;
+            this.component = app.component;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.linkTelephone_title,
+                icon: false,
+                tooltip: redactorTranslations.linkTelephone_tooltip,
+                api: 'plugin.linkTelephone.open'
+            };
+
+            let button = this.toolbar.addButton('linkTelephone', obj);
+            button.setIcon('<i class="re-icon-link"></i><i class="fa fa-phone" style="margin-left: .1em; vertical-align: top;"></i>');
+        },
+
+        open: function () {
+            this.$currentItem = this._getCurrent();
+
+            var options = {
+                title: redactorTranslations.linkTelephone_title,
+                name: 'linkTelephoneModal',
+                width: '500px',
+                height: false,
+                handle: 'insert',
+                commands: {
+                    insert: {title: (this.$currentItem) ? redactorTranslations.save : redactorTranslations.insert},
+                    cancel: {title: redactorTranslations.cancel,}
+                }
+            };
+
+            this.app.api('module.modal.build', options);
+        },
+
+        onmodal: {
+            'linkTelephoneModal': {
+                open: function ($modal, $form) {
+                    if (this.selection.getText() !== '') {
+                        $form.setData({
+                            'linkTelephoneText': this.selection.getText()
+                        });
+                    }
+                },
+                opened: function ($modal, $form) {
+                    $form.getField('linkTelephoneNumber').focus();
+                    if (this.$currentItem) {
+                        let $el = $R.dom(this.$currentItem);
+                        let email = decodeURI($el.attr('href').substring(4));
+                        let text = $el.text();
+                        $form.getField('linkTelephoneNumber').val(email);
+                        $form.getField('linkTelephoneText').val(text);
+                    }
+                },
+                insert: function ($modal, $form) {
+                    let data = $form.getData();
+                    if (this._validateData($form, data)) {
+                        this._insert(data);
+                    }
+                },
+            }
+        },
+
+        modals: {
+            'linkTelephoneModal': '<form action="">'
+                + '<div class="form-item">'
+                + '<label>' + redactorTranslations.linkTelephone_label_number + ' <span class="req">*</span</label>'
+                + '<input name="linkTelephoneNumber" type="text" />'
+                + '<span class="desc">' + redactorTranslations.linkTelephone_notice_number + '</span>'
+                + '</div>'
+                + '<div class="form-item">'
+                + '<label>' + redactorTranslations.linkTelephone_label_text + '</label>'
+                + '<input name="linkTelephoneText" type="text" />'
+                + '</div>'
+                + '</form>'
+        },
+
+        oncontextbar: function (e, contextbar) {
+
+            let data = this.inspector.parse(e.target);
+            if (data.isLink()) {
+                let node = data.getLink();
+                let $el = $R.dom(node);
+
+                let url = $el.attr('href');
+                if (url.substring(0, 4) === 'tel:') {
+                    let $point = $R.dom('<a>');
+
+                    $point.text(url.substring(4));
+                    $point.attr('href', url);
+
+                    var buttons = {
+                        'link': {
+                            title: $point,
+                            html: url.substring(4)
+                        },
+                        'edit': {
+                            title: redactorTranslations.edit,
+                            api: 'plugin.linkTelephone.open',
+                            args: node
+                        },
+                        'unlink': {
+                            title: redactorTranslations.unlink,
+                            api: 'module.link.unlink'
+                        }
+                    };
+                    contextbar.set(e, node, buttons, 'bottom');
+                }
+            }
+        },
+
+        _getCurrent: function () {
+            var current = this.selection.getCurrent();
+            var data = this.inspector.parse(current);
+            if (data.isLink()) {
+                return this.component.build(data.getLink());
+            }
+        },
+
+        _insert: function (data) {
+            // close the modal
+            this.app.api('module.modal.close');
+
+            // check the data
+            if (data.linkTelephoneText.trim() === '') {
+                data.linkTelephoneText = data.linkTelephoneNumber;
+            }
+
+            let current = this._getCurrent();
+            if (current) {
+                let element = $R.dom(current);
+                element.attr('href', 'tel:'+data.linkTelephoneNumber);
+                element.text(data.linkTelephoneText);
+            } else {
+                this.insertion.insertRaw('<a href="tel:' + data.linkTelephoneNumber + '">' + data.linkTelephoneText + '</a>');
+            }
+        },
+
+        _validateData: function ($form, data) {
+            let regex = /^\+(?:[0-9] ?){6,14}[0-9]$/;
+            return regex.test(data.linkTelephoneNumber) ? true : $form.setError('linkTelephoneNumber');
+        },
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/linkYForm.js
+++ b/assets/plugins.vanilla/linkYForm.js
@@ -1,0 +1,84 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+/**
+ * = = = = = = = = = = = = = = = = = = = = =
+ * Don't use this
+ * = = = = = = = = = = = = = = = = = = = = =
+ */
+(function ($R) {
+    $R.add('plugin', 'linkYForm', {
+        init: function (app) {
+            this.app = app;
+            this.opts = app.opts;
+            this.toolbar = app.toolbar;
+            this.insertion = app.insertion;
+            this.selection = app.selection;
+
+            if ('redaxo' in this.opts && 'linkYForm' in this.opts.redaxo) {
+                this.yform = app.opts.redaxo.linkYForm;
+            } else {
+                return false;
+            }
+        },
+
+        // public
+        start: function () {
+            let dropdown = {};
+            this.yform.forEach((data, i) => {
+                dropdown[i] = {
+                    title: data[0],
+                    api: 'plugin.linkYForm.open',
+                    args: {
+                        table: data[0],
+                        label: data[1]
+                    }
+                };
+            });
+
+            let obj = {
+                title: redactorTranslations.linkYForm_title,
+                api: 'plugin.linkYForm.open'
+            };
+
+            let button = this.toolbar.addButton('linkYForm', obj);
+            button.setDropdown(dropdown);
+        },
+
+        open: function (data) {
+            let that = this;
+            let eventFired = false;
+            let pool = newPoolWindow('index.php?page=yform/manager/data_edit&table_name=' + data.table + '&rex_yform_manager_opener[id]=1&rex_yform_manager_opener[field]=' + data.label + '&rex_yform_manager_opener[multiple]=0');
+            $(pool).on('rex:YForm_selectData', function (event, id, label) {
+                event.preventDefault();
+                pool.close();
+
+                if (!eventFired) {
+                    label = label.replace(new RegExp(that.opts.redaxo.regex.id, 'gi'), "$1");
+                    let options = {
+                        url: data.table.split('_').join('-') + '://' + id,
+                        label: label
+                    };
+                    that._insert(options);
+                    eventFired = true;
+                }
+            });
+        },
+
+        // private
+        _insert: function (data) {
+            if (this.selection.getText() !== '') {
+                data.label = this.selection.getText();
+            }
+            this.insertion.insertRaw('<a href="' + data.url + '">' + data.label + '</a>');
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/lists.js
+++ b/assets/plugins.vanilla/lists.js
@@ -1,0 +1,70 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'lists', {
+        init: function (app) {
+            this.opts = app.opts;
+            this.toolbar = app.toolbar;
+
+            this.listsopts = ['ul', 'ol', 'outdent', 'indent'];
+
+            if ('redaxo' in this.opts && 'lists' in this.opts.redaxo) {
+                this.listsopts = app.opts.redaxo.lists;
+            }
+        },
+
+        // public
+        start: function () {
+
+            let dropdown = {
+                observe: 'list'
+            };
+
+            if (this.listsopts.indexOf('ul') !== -1) {
+                dropdown.unorderedlist = {
+                    title: redactorTranslations.ul_title,
+                    api: 'module.list.toggle',
+                    args: 'ul'
+                }
+            }
+
+            if (this.listsopts.indexOf('ol') !== -1) {
+                dropdown.orderedlist = {
+                    title: redactorTranslations.ol_title,
+                    api: 'module.list.toggle',
+                    args: 'ol'
+                }
+            }
+
+            if (this.listsopts.indexOf('outdent') !== -1) {
+                dropdown.outdent = {
+                    title: redactorTranslations.outdent_title,
+                    api: 'module.list.outdent'
+                }
+            }
+
+            if (this.listsopts.indexOf('indent') !== -1) {
+                dropdown.indent = {
+                    title: redactorTranslations.indent_title,
+                    api: 'module.list.indent'
+                }
+            }
+
+            let obj = {
+                title: redactorTranslations.lists_title,
+                icon: true,
+                observe: 'list'
+            };
+
+            let button = this.toolbar.addButton('lists', obj);
+            button.setDropdown(dropdown);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/ol.js
+++ b/assets/plugins.vanilla/ol.js
@@ -1,0 +1,29 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'ol', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.ol_title,
+                icon: true,
+                api: 'module.list.toggle',
+                observe: 'list',
+                args: 'ol'
+            };
+
+            this.toolbar.addButton('ol', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/outdent.js
+++ b/assets/plugins.vanilla/outdent.js
@@ -1,0 +1,28 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'outdent', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.outdent_title,
+                icon: true,
+                api: 'module.list.outdent',
+                observe: 'list'
+            };
+
+            this.toolbar.addButton('outdent', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/pre.js
+++ b/assets/plugins.vanilla/pre.js
@@ -1,0 +1,31 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'pre', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.pre_title,
+                icon: true,
+                tooltip: redactorTranslations.pre_tooltip,
+                api: 'module.block.format',
+                args: {
+                    tag: 'pre'
+                }
+            };
+
+            this.toolbar.addButton('pre', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/quote.js
+++ b/assets/plugins.vanilla/quote.js
@@ -1,0 +1,116 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'quote', {
+        init: function (app) {
+            this.app = app;
+            this.toolbar = app.toolbar;
+            this.insertion = app.insertion;
+            this.selection = app.selection;
+            this.cleaner = app.cleaner;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.blockquote_title,
+                icon: false,
+                tooltip: redactorTranslations.blockquote_tooltip,
+                api: 'plugin.quote.open',
+                args: {
+                    tag: 'blockquote'
+                }
+            };
+
+            this.toolbar.addButton('quote', obj);
+        },
+
+        open: function() {
+            var options = {
+                title: redactorTranslations.quote_title,
+                name: 'redaxoModal',
+                width: '500px',
+                height: false,
+                handle: 'insert',
+                commands: {
+                    insert: { title: redactorTranslations.quote_insert, },
+                    cancel: { title: redactorTranslations.quote_cancel, }
+                }
+            };
+
+            this.app.api('module.modal.build', options);
+        },
+
+        onmodal: {
+            'redaxoModal': {
+                open: function($modal, $form) {
+                    if (this.selection.getText() !== '') {
+                        $form.setData({
+                            'quoteText': this.selection.getText()
+                        });
+                    }
+                },
+                opened: function($modal, $form) {
+                    $form.getField('quoteText').focus();
+                },
+                insert: function($modal, $form) {
+                    let data = $form.getData();
+                    console.log(data);
+                    this._insert(data);
+                }
+            }
+        },
+
+        modals: {
+            'redaxoModal': '<form action="">'
+                + '<div class="form-item">'
+                    + '<label>'+redactorTranslations.quote_label_text+'</label>'
+                    + '<textarea name="quoteText" style="height: 200px;"></textarea>'
+                + '</div>'
+                + '<div class="form-item">'
+                    + '<label>'+redactorTranslations.quote_label_author+'</label>'
+                    + '<input name="quoteAuthor" type="text" />'
+                + '</div>'
+                + '<div class="form-item">'
+                    + '<label>'+redactorTranslations.quote_label_cite+'</label>'
+                    + '<input name="quoteCite" type="text" />'
+                + '</div>'
+            + '</form>'
+        },
+
+        _insert: function(data) {
+            // close the modal
+            this.app.api('module.modal.close');
+
+            // check the data
+            if (data.quoteText.trim() === '') {
+                return;
+            }
+
+            let cite = '';
+            if (data.quoteCite.trim() !== '') {
+                 cite = '<cite>'+data.quoteCite+'</cite>';
+            }
+
+            let author = '';
+            if (data.quoteAuthor.trim() !== '') {
+                author = data.quoteAuthor;
+                if (cite !== '') {
+                    author += ', '+cite;
+                    cite = '';
+                }
+                author = '<footer>'+author+'</footer>';
+            }
+
+            // insert data with Insertion Service
+            this.insertion.insertHtml('<blockquote><div>'+this.cleaner.paragraphize(data.quoteText)+'</div>'+author+cite+'</blockquote>');
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/redo.js
+++ b/assets/plugins.vanilla/redo.js
@@ -1,0 +1,27 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'redo', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.redo_title,
+                icon: true,
+                api: 'module.buffer.redo'
+            };
+
+            this.toolbar.addButton('redo', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/separator.js
+++ b/assets/plugins.vanilla/separator.js
@@ -1,0 +1,25 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', '|', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {};
+
+            let button = this.toolbar.addButton('separator', obj);
+            button.hideTooltip();
+            button.disable();
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/style.js
+++ b/assets/plugins.vanilla/style.js
@@ -1,0 +1,48 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'style', {
+        init: function (app) {
+            this.opts = app.opts;
+            this.toolbar = app.toolbar;
+
+            this.listsopts = ['mark', 'code', 'var', 'kbd', 'sup', 'sub'];
+
+            if ('redaxo' in this.opts && 'style' in this.opts.redaxo) {
+                this.listsopts = app.opts.redaxo.style;
+            }
+        },
+
+        // public
+        start: function () {
+
+            let dropdown = {};
+
+            for (let key in this.listsopts) {
+                let element = this.listsopts[key];
+                let title = 'style_'+element+'_title';
+                dropdown[element] = {
+                    title: redactorTranslations[title],
+                    api: 'module.inline.format',
+                    args: element
+                }
+            }
+
+            let obj = {
+                title: redactorTranslations.style_title,
+                icon: true,
+            };
+
+            let button = this.toolbar.addButton('style', obj);
+            button.setIcon('<i class="re-icon-inline"></i>');
+            button.setDropdown(dropdown);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/sub.js
+++ b/assets/plugins.vanilla/sub.js
@@ -1,0 +1,31 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'subscript', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.subscript_title,
+                icon: true,
+                tooltip: redactorTranslations.subscript_tooltip,
+                api: 'module.inline.format',
+                args: {
+                    tag: 'sub'
+                }
+            };
+
+            this.toolbar.addButton('subscript', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/sup.js
+++ b/assets/plugins.vanilla/sup.js
@@ -1,0 +1,31 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'superscript', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.superscript_title,
+                icon: true,
+                tooltip: redactorTranslations.superscript_tooltip,
+                api: 'module.inline.format',
+                args: {
+                    tag: 'sup'
+                }
+            };
+
+            this.toolbar.addButton('superscript', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/ul.js
+++ b/assets/plugins.vanilla/ul.js
@@ -1,0 +1,29 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'ul', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.ul_title,
+                icon: true,
+                api: 'module.list.toggle',
+                observe: 'list',
+                args: 'ul'
+            };
+
+            this.toolbar.addButton('ul', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/underline.js
+++ b/assets/plugins.vanilla/underline.js
@@ -1,0 +1,31 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'underline', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.underline_title,
+                icon: true,
+                tooltip: redactorTranslations.underline_tooltip,
+                api: 'module.inline.format',
+                args: {
+                    tag: 'u'
+                }
+            };
+
+            this.toolbar.addButton('underline', obj);
+        }
+    });
+})(Redactor);

--- a/assets/plugins.vanilla/undo.js
+++ b/assets/plugins.vanilla/undo.js
@@ -1,0 +1,27 @@
+/**
+ * This file is part of the redactor package.
+ *
+ * @author (c) Friends Of REDAXO
+ * @author <friendsof@redaxo.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+(function ($R) {
+    $R.add('plugin', 'undo', {
+        init: function (app) {
+            this.toolbar = app.toolbar;
+        },
+
+        // public
+        start: function () {
+            let obj = {
+                title: redactorTranslations.undo_title,
+                icon: true,
+                api: 'module.buffer.undo'
+            };
+
+            this.toolbar.addButton('undo', obj);
+        }
+    });
+})(Redactor);

--- a/assets/redactor.vanilla.js
+++ b/assets/redactor.vanilla.js
@@ -1,0 +1,21 @@
+document.addEventListener('rex:ready', function(event) {
+    const container = event.detail || document;
+    const elements = container.querySelectorAll('[class*="redactor-editor--"]');
+    
+    elements.forEach(function(element) {
+        const classNames = element.className.split(' ');
+        classNames.forEach(function(className) {
+            if (className.startsWith('redactor-editor--')) {
+                const profile = className.substring('redactor-editor--'.length);
+                if (profile !== '' && redactor_profiles[profile]) {
+                    const options = { ...redactor_profiles[profile] };
+                    options.lang = redactorLang;
+                    if (!('pasteImages' in options)) {
+                        options.pasteImages = false;
+                    }
+                    $R('.redactor-editor--' + profile, options);
+                }
+            }
+        });
+    });
+});

--- a/boot.php
+++ b/boot.php
@@ -16,8 +16,8 @@ $addon = rex_addon::get('redactor');
 if (rex::isBackend() && rex::getUser()) {
 
     rex_extension::register('REDACTOR_PLUGIN_DIR', function (rex_extension_point $ep) {
-        if(rex_config::get('redactor', 'use_vanilla_js') == 1) {
-            $ep->setSubject([rex_path::addon('redactor', 'plugins.vanilla')]); // Verzeichnis überschreiben
+        if(rex_config::get('redactor', 'use_vanilla_js') == '|1|') {
+            $ep->setSubject([rex_addon::get('redactor')->getAssetsPath('plugins.vanilla')]); // Verzeichnis überschreiben
         }
     });
 
@@ -54,7 +54,7 @@ if (rex::isBackend() && rex::getUser()) {
         rex_view::addJsFile($addon->getAssetsUrl('vendor/redactor/langs/'.substr($userLang, 0, 2).'.js'));
         rex_view::addJsFile($addon->getAssetsUrl('cache/plugins.'.$userLang.'.js'));
         rex_view::addJsFile($addon->getAssetsUrl('cache/profiles.js'));
-        if(rex_addon::get('redactor')->getConfig('use_vanilla_js') == 1) {
+        if(rex_addon::get('redactor')->getConfig('use_vanilla_js') == '|1|') {
             rex_view::addJsFile($addon->getAssetsUrl('redactor.vanilla.js'));
         } else {
             rex_view::addJsFile($addon->getAssetsUrl('redactor.js'));

--- a/boot.php
+++ b/boot.php
@@ -15,6 +15,12 @@ $addon = rex_addon::get('redactor');
 
 if (rex::isBackend() && rex::getUser()) {
 
+    rex_extension::register('REDACTOR_PLUGIN_DIR', function (rex_extension_point $ep) {
+        if(rex_config::get('redactor', 'use_vanilla_js') == 1) {
+            $ep->setSubject([rex_path::addon('redactor', 'plugins.vanilla')]); // Verzeichnis überschreiben
+        }
+    });
+
     rex_extension::register('PACKAGES_INCLUDED', function() use ($addon) {
 
         if ($this->getProperty('compile')) {
@@ -48,7 +54,11 @@ if (rex::isBackend() && rex::getUser()) {
         rex_view::addJsFile($addon->getAssetsUrl('vendor/redactor/langs/'.substr($userLang, 0, 2).'.js'));
         rex_view::addJsFile($addon->getAssetsUrl('cache/plugins.'.$userLang.'.js'));
         rex_view::addJsFile($addon->getAssetsUrl('cache/profiles.js'));
-        rex_view::addJsFile($addon->getAssetsUrl('redactor.js'));
+        if(rex_addon::get('redactor')->getConfig('use_vanilla_js') == 1) {
+            rex_view::addJsFile($addon->getAssetsUrl('redactor.vanilla.js'));
+        } else {
+            rex_view::addJsFile($addon->getAssetsUrl('redactor.js'));
+        }
 
         rex_view::setJsProperty('redactor_rex_clang_getCurrentId', rex_clang::getCurrentId());
         rex_view::setJsProperty('redactor_rex_url_media', '/media/');

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -2,7 +2,8 @@ redactor_title = Redactor
 
 redactor_error_save_profile = Profile konnten nicht erstellt werden.
 
-redactor_help = Dokumentation
+redactor_help = Docs
+redactor_settings = Einstellungen
 
 redactor_clear_cache = Cache löschen
 redactor_cache_deleted = Cache wurde gelöscht
@@ -174,3 +175,5 @@ redactor_plugin_vendor_video_html_code = Video-Einbettungscode oder Youtube/Vime
 # Widget
 redactor_plugin_vendor_widget = Widget
 redactor_plugin_vendor_widget_html_code = Widget HTML Code
+
+redactor_settings_use_vanilla_js = Modernes JavaScript verwenden anstelle von jQuery.

--- a/package.yml
+++ b/package.yml
@@ -24,6 +24,10 @@ page:
     subpages:
         profile:
             title: 'translate:profiles'
+        settings:
+            title: 'translate:redactor_settings'
+            icon: rex-icon fa-cog
+            itemClass: 'pull-right'
         help:
             title: 'translate:help'
             icon: rex-icon fa-info-circle
@@ -199,3 +203,6 @@ editor:
         multipleUpload: true
         clipboardUpload: true
         uploadData: false
+
+default_config:
+    use_vanilla_js: ''

--- a/pages/profile.php
+++ b/pages/profile.php
@@ -143,10 +143,10 @@ if ($func == 'add' || $func == 'edit') {
         $selector = substr($params['list']->getValue('selector'), 1);
         $generic_code = ''.$params['list']->getValue('selector').'';
         $return = '';
-        $return .= '<clipboard-copy for="redactor-generic-'.$params['list']->getValue('id').'" class="btn btn-copy btn-default"><i class="rex-icon fa-clone"></i></clipboard-copy>';
-        $return .= ' <div id="redactor-generic-'.$params['list']->getValue('id').'" class="visible-lg-inline-block"><code>' . $generic_code . '</code></div>';
-        $return .= '<br><clipboard-copy for="redactor-yform-'.$params['list']->getValue('id').'" class="btn btn-copy btn-default"><i class="rex-icon fa-clone"></i></clipboard-copy>';
-        $return .= ' <div id="redactor-yform-'.$params['list']->getValue('id').'" class="visible-lg-inline-block"><code>' . $yform_code . '</code></div>';
+        $return .= '<clipboard-copy for="redactor-generic-'.$params['list']->getValue('id').'" class="btn btn-copy btn-text"><i class="rex-icon fa-clone"></i> <code>'.$generic_code.'</code></clipboard-copy>';
+        $return .= '<div class="hidden" id="redactor-generic-'.$params['list']->getValue('id').'"><code>'.$generic_code.'</code></div>';
+        $return .= '<br><clipboard-copy for="redactor-yform-'.$params['list']->getValue('id').'" class="btn btn-copy btn-text"><i class="rex-icon fa-clone"></i> <code>'.$yform_code.'</code></clipboard-copy>';
+        $return .= '<div class="hidden" id="redactor-yform-'.$params['list']->getValue('id').'"><code>'.$yform_code.'</code></div>';
 
         return $return;
 

--- a/pages/settings.php
+++ b/pages/settings.php
@@ -1,0 +1,22 @@
+<?php
+
+/** @var rex_addon $this */
+
+$form = rex_config_form::factory('redactor');
+
+$form->addFieldset(rex_i18n::msg('redactor_settings'));
+
+// Checkbox für experimentelle Funktion "Vanilla JS statt JQuery verwenden"
+
+$field = $form->addCheckboxField('use_vanilla_js');
+
+$field->addOption(rex_i18n::msg('redactor_settings_use_vanilla_js'), '1');
+
+// Ausgabe in Container-Fragment
+
+$fragment = new rex_fragment();
+$fragment->setVar('title', rex_i18n::msg('redactor_settings'));
+$fragment->setVar('body', $form->get(), false);
+$content = $fragment->parse('core/page/section.php');
+
+echo $content;


### PR DESCRIPTION
100% abwärtskompatibel: Fügt eine neue Einstellung hinzu, mit der die Änderungen an redactor.js und den Plugins getestet werden können.

Motivation: REDACTOR auch im "Frontend" (YCom-Bereich, o.ä.) einsetzen können, wenn kein jQuery und kein `rex:ready` verfügbar ist.